### PR TITLE
Add Antique Atlas to whitelist

### DIFF
--- a/src/main/java/vazkii/akashictome/ConfigHandler.java
+++ b/src/main/java/vazkii/akashictome/ConfigHandler.java
@@ -34,7 +34,8 @@ public class ConfigHandler {
 						"theoneprobe:probenote",
 						"evilcraft:origins_of_darkness",
 						"draconicevolution:info_tablet",
-						"charset:tablet"));
+						"charset:tablet",
+						"antiqueatlas:antique_atlas"));
 		
 		whitelistedNames = builder.define("Whitelisted Names", Arrays.asList("book", "tome", "lexicon", "nomicon", "manual", "knowledge", "pedia", "compendium", "guide", "codex", "journal"));
 		


### PR DESCRIPTION
Adds the Antique Atlas from [the titular mod](https://www.curseforge.com/minecraft/mc-mods/antique-atlas) to the whitelist.