### PR TITLE
Allow duplicates or multiple books from same mod

### DIFF
--- a/src/main/java/vazkii/akashictome/AttachementRecipe.java
+++ b/src/main/java/vazkii/akashictome/AttachementRecipe.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import vazkii.arl.util.ItemNBTHelper;
 
 public class AttachementRecipe extends SpecialRecipe {
 
@@ -64,10 +65,15 @@ public class AttachementRecipe extends SpecialRecipe {
 
 		CompoundNBT morphData = cmp.getCompound(MorphingHandler.TAG_TOME_DATA);
 		String mod = MorphingHandler.getModFromStack(target);
+		String modClean = mod;
+		int iter = 1;
+		
+		while(morphData.contains(mod)) {
+			mod = modClean + iter;
+			iter++;
+		}
 
-		if(morphData.contains(mod))
-			return ItemStack.EMPTY;
-
+		ItemNBTHelper.setString(target, MorphingHandler.TAG_ITEM_DEFINED_MOD, mod);
 		CompoundNBT modCmp = new CompoundNBT();
 		target.write(modCmp);
 		morphData.put(mod, modCmp);

--- a/src/main/java/vazkii/akashictome/MorphingHandler.java
+++ b/src/main/java/vazkii/akashictome/MorphingHandler.java
@@ -120,7 +120,7 @@ public final class MorphingHandler {
 	}
 
 	public static ItemStack makeMorphedStack(ItemStack currentStack, String targetMod, CompoundNBT morphData) {
-		String currentMod = getModFromStack(currentStack);
+		String currentMod = ItemNBTHelper.getString(currentStack, TAG_ITEM_DEFINED_MOD, getModFromStack(currentStack));
 
 		CompoundNBT currentCmp = new CompoundNBT();
 		currentStack.write(currentCmp);


### PR DESCRIPTION
Fixes #53 and #67. This used to be a feature, and is still listed in the mod description, but got broken somewhere along the line. Fixed by reusing the code from when it still worked.