### PR TITLE
Add parameterless constructor to morph message

### DIFF
--- a/src/main/java/vazkii/akashictome/network/MessageMorphTome.java
+++ b/src/main/java/vazkii/akashictome/network/MessageMorphTome.java
@@ -12,7 +12,9 @@ import vazkii.arl.network.IMessage;
 @SuppressWarnings("serial")
 public class MessageMorphTome implements IMessage {
 
-	private final String modid;
+	public String modid;
+	
+	public MessageMorphTome() {}
 
 	public MessageMorphTome(String modid) {
 		this.modid = modid;


### PR DESCRIPTION
Fixes #83

From the error message posted in that issue I traced the error to `vazkii.arl.network.NetworkHandler`, which expects all messages to have a constructor with no parameters.

`MessageMorphTome` implements a single constructor which takes a parameter. As a result, `NetworkHandler` errors out whenever it tries to deserialize the morph message, preventing the Tome from morphing into any of the books it contains.

I fixed this by making adding a parameterless constructor to `MessageMorphTome` and removing `static` from `modid`. I didn't touch the existing constructor, so this shouldn't break anything else.

I've tested this locally on my client with no issues.