### PR TITLE
Avoid modifying currentStack in makeMorphedStack

### DIFF
--- a/src/main/java/vazkii/akashictome/MorphingHandler.java
+++ b/src/main/java/vazkii/akashictome/MorphingHandler.java
@@ -119,6 +119,7 @@ public final class MorphingHandler {
 	}
 
 	public static ItemStack makeMorphedStack(ItemStack currentStack, String targetMod, boolean calledOnRemove) {
+		currentStack = currentStack.copy();
 		String currentMod = getModFromStack(currentStack);
 
 		String defined = "";


### PR DESCRIPTION
Fixes #122.

When shift-right-clicking the tome on a block, the current behavior removes the tool content from the tome item stack. If the tome has an entry corresponding to the clicked block, then this doesn't matter as the current stack is replaced with the new stack from makeMorphedStack. However, if the tome lacks a corresponding entry (such as when the block is from vanilla Minecraft), then the current stack is never replaced, leaving the player with a broken tome.

This change prevents the problem by creating a copy of the current tome item stack in makeMorphedStack, which is then updated in place of the original.